### PR TITLE
More time for framework completely stop

### DIFF
--- a/gui/run_experiment_tab.py
+++ b/gui/run_experiment_tab.py
@@ -222,7 +222,7 @@ class Run_experiment_tab(QtGui.QWidget):
             # Stop running boards.
             if board.framework_running:
                 board.stop_framework()
-                time.sleep(0.01)
+                time.sleep(0.05)
                 board.process_data()
                 self.subjectboxes[i].task_stopped()
         # Summary and persistent variables.


### PR DESCRIPTION
Fixes bug that occurred when sending an audio player "stop" message at the end of a session. See: https://groups.google.com/forum/#!topic/pycontrol/sOp8ZIt3lxE